### PR TITLE
Fix GitHub URL

### DIFF
--- a/rhombus-theme.el
+++ b/rhombus-theme.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2015 Ross Donaldson
 
 ;; Author: Ross Donaldson <gastove@gmail.com>
-;; URL: https://github.com/Gastove/rhombus-theme
+;; URL: https://github.com/Gastove/rhombus
 ;; Version 1.0.0
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
URL was listed as https://github.com/Gastove/rhombus-theme instead of https://github.com/Gastove/rhombus
